### PR TITLE
Change debian jessie docker image to debian stable-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stable-slim
 RUN apt-get update
 RUN apt-get install -y wget bsdmainutils
 ADD . /maldet


### PR DESCRIPTION
Debian jessie reached its end of life, and the certificates for the package management expired. So it fails to install  wget bsdmainutils, that's why build fails. 

Changed docker image to the stable slim